### PR TITLE
Update clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Navigate to your Sublime Text packages directory:
 If you're using Sublime Text 2, replace 3 with 2 in the paths above.
 
 Then clone this repository:
-`git clone https://github.com/karthikv/tradeship-sublime.git`.
+`git clone https://github.com/karthikv/tradeship-sublime.git ./tradeship`.
 
 ## Usage
 To run tradeship, you may either:


### PR DESCRIPTION
Update clone command to clone tradeship-sublime into `./tradeship` instead of `./tradeship-sublime`. 

Sublime looks for `tradeship.sublime-settings` at `.../Packages/tradeship/tradeship.sublime-settings`. This places that file in the correct place.